### PR TITLE
[5.3] Stricter comparison when replacing URL for LocalAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -295,8 +295,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
             $path = '/storage/'.$path;
 
-            return Str::contains($path, '/storage/public') ?
-                        Str::replaceFirst('/public', '', $path) : $path;
+            return Str::contains($path, '/storage/public/') ?
+                        Str::replaceFirst('/public/', '/', $path) : $path;
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');
         }


### PR DESCRIPTION
I have an edgy case with a directory name that starts with string `public`, like this:
- `/storage/app/public/public.../files`

So this was triggering the ternary on line `298` and the resulting URL was broken.
Here is a real example:
- Upload public path for LocalAdapter is `publicala/logo.svg`, full path from project root being `/storage/app/public/publicala/logo.svg`.
- Generated URL was `https://laravelapp.dev/storageala/logo.svg`
With this litle patch the generated URL is `https://laravelapp.dev/storage/publicala/logo.svg`

This would also be useful for directory names ending with string `public`